### PR TITLE
Add method to update metadata renderer target

### DIFF
--- a/src/ERC721Drop.sol
+++ b/src/ERC721Drop.sol
@@ -51,7 +51,7 @@ contract ERC721Drop is
     IERC721Drop,
     OwnableSkeleton,
     FundsReceiver,
-    Version(7),
+    Version(8),
     ERC721DropStorageV1
 {
     /// @dev This is the max mint batch size for the optimized ERC721A mint contract
@@ -76,14 +76,6 @@ contract ERC721Drop is
     /// @notice Max royalty BPS
     uint16 constant MAX_ROYALTY_BPS = 50_00;
 
-    event SalesConfigChanged(address indexed changedBy);
-
-    event FundsRecipientChanged(
-        address indexed newAddress,
-        address indexed changedBy
-    );
-
-    event OpenMintFinalized(address indexed sender, uint256 numberOfMints);
 
     /// @notice Only allow for users with admin access
     modifier onlyAdmin() {
@@ -229,6 +221,7 @@ contract ERC721Drop is
     function _authorizeUpgrade(address newImplementation)
         internal
         override
+        view
         onlyAdmin
     {
         if (
@@ -748,6 +741,25 @@ contract ERC721Drop is
     /// @param newOwner new owner to set
     function setOwner(address newOwner) public onlyAdmin {
         _setOwner(newOwner);
+    }
+
+    /// @notice Set a new metadata renderer
+    /// @param newRenderer new renderer address to use
+    /// @param setupRenderer data to setup new renderer with
+    function setMetadataRenderer(
+        IMetadataRenderer newRenderer,
+        bytes memory setupRenderer
+    ) external onlyAdmin {
+        config.metadataRenderer = newRenderer;
+
+        if (setupRenderer.length > 0) {
+            newRenderer.initializeWithData(setupRenderer);
+        }
+
+        emit UpdatedMetadataRenderer({
+            sender: msg.sender,
+            renderer: newRenderer
+        });
     }
 
     //                       ,-.

--- a/src/interfaces/IERC721Drop.sol
+++ b/src/interfaces/IERC721Drop.sol
@@ -66,6 +66,30 @@ interface IERC721Drop {
         uint256 firstPurchasedTokenId
     );
 
+    /// @notice Sales configuration has been changed
+    /// @dev To access new sales configuration, use getter function.
+    /// @param changedBy Changed by user
+    event SalesConfigChanged(address indexed changedBy);
+
+    /// @notice Event emitted when the funds recipient is changed
+    /// @param newAddress new address for the funds recipient
+    /// @param changedBy address that the recipient is changed by
+    event FundsRecipientChanged(
+        address indexed newAddress,
+        address indexed changedBy
+    );
+
+    /// @notice Event emitted when an open mint is finalized and further minting is closed forever on the contract.
+    /// @param sender address sending close mint
+    /// @param numberOfMints number of mints the contract is finalized at
+    event OpenMintFinalized(address indexed sender, uint256 numberOfMints);
+
+    /// @notice Event emitted when metadata renderer is updated.
+    /// @param sender address of the updater
+    /// @param renderer new metadata renderer address
+    event UpdatedMetadataRenderer(address sender, IMetadataRenderer renderer);
+
+
     /// @notice General configuration for NFT Minting and bookkeeping
     struct Configuration {
         /// @dev Metadata renderer (uint160)
@@ -164,6 +188,11 @@ interface IERC721Drop {
 
     /// @notice This is the opensea/public owner setting that can be set by the contract admin
     function owner() external view returns (address);
+
+    /// @notice Update the metadata renderer
+    /// @param newRenderer new address for renderer
+    /// @param setupRenderer data to call to bootstrap data for the new renderer (optional)
+    function setMetadataRenderer(IMetadataRenderer newRenderer, bytes memory setupRenderer) external;
 
     /// @notice This is an admin mint function to mint a quantity to a specific address
     /// @param to address to mint to


### PR DESCRIPTION
Allows for migration of metadata renderer backend for upgrades to broken metadata or presale/postsale migration.