### PR TITLE
Updating sales config update issue and emitting event on withdraws

### DIFF
--- a/src/ERC721Drop.sol
+++ b/src/ERC721Drop.sol
@@ -76,7 +76,6 @@ contract ERC721Drop is
     /// @notice Max royalty BPS
     uint16 constant MAX_ROYALTY_BPS = 50_00;
 
-
     /// @notice Only allow for users with admin access
     modifier onlyAdmin() {
         if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
@@ -220,8 +219,8 @@ contract ERC721Drop is
     /// @dev Only can be called by admin
     function _authorizeUpgrade(address newImplementation)
         internal
-        override
         view
+        override
         onlyAdmin
     {
         if (
@@ -803,7 +802,7 @@ contract ERC721Drop is
         uint64 presaleStart,
         uint64 presaleEnd,
         bytes32 presaleMerkleRoot
-    ) external onlyAdmin {
+    ) external onlyRoleOrAdmin(SALES_MANAGER_ROLE) {
         // SalesConfiguration storage newConfig = SalesConfiguration({
         //     publicSaleStart: publicSaleStart,
         //     publicSaleEnd: publicSaleEnd,
@@ -925,6 +924,7 @@ contract ERC721Drop is
             funds
         );
 
+        // Check if withdrawn is allowed
         if (
             !hasRole(DEFAULT_ADMIN_ROLE, sender) &&
             !hasRole(SALES_MANAGER_ROLE, sender) &&
@@ -954,6 +954,15 @@ contract ERC721Drop is
         if (!successFunds) {
             revert Withdraw_FundsSendFailure();
         }
+
+        // Emit event for indexing
+        emit FundsWithdrawn(
+            msg.sender,
+            config.fundsRecipient,
+            funds,
+            feeRecipient,
+            zoraFee
+        );
     }
 
     //                       ,-.

--- a/src/interfaces/IERC721Drop.sol
+++ b/src/interfaces/IERC721Drop.sol
@@ -79,6 +79,20 @@ interface IERC721Drop {
         address indexed changedBy
     );
 
+    /// @notice Event emitted when the funds are withdrawn from the minting contract
+    /// @param withdrawnBy address that issued the withdraw
+    /// @param withdrawnTo address that the funds were withdrawn to
+    /// @param amount amount that was withdrawn
+    /// @param feeRecipient user getting withdraw fee (if any)
+    /// @param feeAmount amount of the fee getting sent (if any)
+    event FundsWithdrawn(
+        address indexed withdrawnBy,
+        address indexed withdrawnTo,
+        uint256 amount,
+        address feeRecipient,
+        uint256 feeAmount
+    );
+
     /// @notice Event emitted when an open mint is finalized and further minting is closed forever on the contract.
     /// @param sender address sending close mint
     /// @param numberOfMints number of mints the contract is finalized at


### PR DESCRIPTION
WIP: Need to add tests for event and access updates.

* fix sales config access control allowing SALES_MANAGER_ROLE
* updating `msg.sender` to use `_msgSender()` across the board for consistency
* adding a new indexer event on withdraw
Fixes #48 and #47