### PR TITLE
Update metadata rendering paths (remove ?id=ID from animation and image in edition)

### DIFF
--- a/src/utils/NFTMetadataRenderer.sol
+++ b/src/utils/NFTMetadataRenderer.sol
@@ -1,34 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
-import {StringsUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {Base64} from "@openzeppelin/contracts/utils/Base64.sol";
 import {IPublicSharedMetadata} from "../interfaces/IPublicSharedMetadata.sol";
 
-/// Shared NFT logic for rendering metadata associated with editions
-/// @dev Can safely be used for generic base64Encode and numberToString functions
-contract SharedNFTLogic is IPublicSharedMetadata {
-    /// @param unencoded bytes to base64-encode
-    function base64Encode(bytes memory unencoded)
-        public
-        pure
-        override
-        returns (string memory)
-    {
-        return Base64.encode(unencoded);
-    }
-
-    /// Proxy to openzeppelin's toString function
-    /// @param value number to return as a string
-    function numberToString(uint256 value)
-        public
-        pure
-        override
-        returns (string memory)
-    {
-        return StringsUpgradeable.toString(value);
-    }
-
+/// NFT metadata library for rendering metadata associated with editions
+library NFTMetadataRenderer {
     /// Generate edition metadata from storage information as base64-json blob
     /// Combines the media data and metadata
     /// @param name Name of NFT in metadata
@@ -44,7 +22,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         string memory animationUrl,
         uint256 tokenOfEdition,
         uint256 editionSize
-    ) external pure returns (string memory) {
+    ) internal pure returns (string memory) {
         string memory _tokenMediaData = tokenMediaData(
             imageUrl,
             animationUrl,
@@ -60,6 +38,30 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         return encodeMetadataJSON(json);
     }
 
+    function encodeContractURIJSON(
+        string memory name,
+        string memory description,
+        string memory imageURI
+    ) internal pure returns (string memory) {
+        bytes memory imageSpace = bytes("");
+        if (bytes(imageURI).length > 0) {
+            imageSpace = abi.encodePacked('", "image": "', imageURI);
+        }
+        return
+            string(
+                encodeMetadataJSON(
+                    abi.encodePacked(
+                        '{"name": "',
+                        name,
+                        '", "description": "',
+                        description,
+                        imageSpace,
+                        '"}'
+                    )
+                )
+            );
+    }
+
     /// Function to create the metadata json string for the nft edition
     /// @param name Name of NFT in metadata
     /// @param description Description of NFT in metadata
@@ -72,12 +74,12 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         string memory mediaData,
         uint256 tokenOfEdition,
         uint256 editionSize
-    ) public pure returns (bytes memory) {
+    ) internal pure returns (bytes memory) {
         bytes memory editionSizeText;
         if (editionSize > 0) {
             editionSizeText = abi.encodePacked(
                 "/",
-                numberToString(editionSize)
+                Strings.toString(editionSize)
             );
         }
         return
@@ -85,7 +87,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                 '{"name": "',
                 name,
                 " ",
-                numberToString(tokenOfEdition),
+                Strings.toString(tokenOfEdition),
                 editionSizeText,
                 '", "',
                 'description": "',
@@ -93,7 +95,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                 '", "',
                 mediaData,
                 'properties": {"number": ',
-                numberToString(tokenOfEdition),
+                Strings.toString(tokenOfEdition),
                 ', "name": "',
                 name,
                 '"}}'
@@ -103,16 +105,15 @@ contract SharedNFTLogic is IPublicSharedMetadata {
     /// Encodes the argument json bytes into base64-data uri format
     /// @param json Raw json to base64 and turn into a data-uri
     function encodeMetadataJSON(bytes memory json)
-        public
+        internal
         pure
-        override
         returns (string memory)
     {
         return
             string(
                 abi.encodePacked(
                     "data:application/json;base64,",
-                    base64Encode(json)
+                    Base64.encode(json)
                 )
             );
     }
@@ -125,7 +126,7 @@ contract SharedNFTLogic is IPublicSharedMetadata {
         string memory imageUrl,
         string memory animationUrl,
         uint256 tokenOfEdition
-    ) public pure returns (string memory) {
+    ) internal pure returns (string memory) {
         bool hasImage = bytes(imageUrl).length > 0;
         bool hasAnimation = bytes(animationUrl).length > 0;
         if (hasImage && hasAnimation) {
@@ -135,37 +136,20 @@ contract SharedNFTLogic is IPublicSharedMetadata {
                         'image": "',
                         imageUrl,
                         "?id=",
-                        numberToString(tokenOfEdition),
+                        Strings.toString(tokenOfEdition),
                         '", "animation_url": "',
                         animationUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
                         '", "'
                     )
                 );
         }
         if (hasImage) {
-            return
-                string(
-                    abi.encodePacked(
-                        'image": "',
-                        imageUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        '", "'
-                    )
-                );
+            return string(abi.encodePacked('image": "', imageUrl, '", "'));
         }
         if (hasAnimation) {
             return
                 string(
-                    abi.encodePacked(
-                        'animation_url": "',
-                        animationUrl,
-                        "?id=",
-                        numberToString(tokenOfEdition),
-                        '", "'
-                    )
+                    abi.encodePacked('animation_url": "', animationUrl, '", "')
                 );
         }
 

--- a/test/ZoraNFTCreatorV1.t.sol
+++ b/test/ZoraNFTCreatorV1.t.sol
@@ -10,7 +10,6 @@ import "../src/ZoraFeeManager.sol";
 import "../src/ZoraNFTCreatorProxy.sol";
 import {MockMetadataRenderer} from "./metadata/MockMetadataRenderer.sol";
 import {FactoryUpgradeGate} from "../src/FactoryUpgradeGate.sol";
-import {SharedNFTLogic} from "../src/utils/SharedNFTLogic.sol";
 import {IERC721AUpgradeable} from "erc721a-upgradeable/IERC721AUpgradeable.sol";
 
 contract ZoraFeeManagerTest is DSTest {
@@ -32,13 +31,12 @@ contract ZoraFeeManagerTest is DSTest {
             DEFAULT_ZORA_DAO_ADDRESS
         );
         vm.prank(DEFAULT_ZORA_DAO_ADDRESS);
-        SharedNFTLogic sharedLogic = new SharedNFTLogic();
         dropImpl = new ERC721Drop(
             feeManager,
             address(1234),
             FactoryUpgradeGate(address(0))
         );
-        editionMetadataRenderer = new EditionMetadataRenderer(sharedLogic);
+        editionMetadataRenderer = new EditionMetadataRenderer();
         dropMetadataRenderer = new DropMetadataRenderer();
         ZoraNFTCreatorV1 impl = new ZoraNFTCreatorV1(
             address(dropImpl),

--- a/test/metadata/EditionMetadataRenderer.t.sol
+++ b/test/metadata/EditionMetadataRenderer.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.10;
 
 import {EditionMetadataRenderer} from "../../src/metadata/EditionMetadataRenderer.sol";
 import {MetadataRenderAdminCheck} from "../../src/metadata/MetadataRenderAdminCheck.sol";
-import {SharedNFTLogic} from "../../src/utils/SharedNFTLogic.sol";
 import {DropMockBase} from "./DropMockBase.sol";
 import {IERC721Drop} from "../../src/interfaces/IERC721Drop.sol";
 import {DSTest} from "ds-test/test.sol";
@@ -40,9 +39,8 @@ contract IERC721OnChainDataMock {
 contract EditionMetadataRendererTest is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);
     address public constant mediaContract = address(123456);
-    SharedNFTLogic public sharedLogic = new SharedNFTLogic();
     EditionMetadataRenderer public editionRenderer =
-        new EditionMetadataRenderer(sharedLogic);
+        new EditionMetadataRenderer();
 
     function test_EditionMetadataInits() public {
         vm.startPrank(address(0x123));
@@ -148,8 +146,8 @@ contract EditionMetadataRendererTest is DSTest {
         editionRenderer.initializeWithData(
             abi.encode("Description", "image", "animation")
         );
-        // '{"name": "MOCK NAME 1/100", "description": "Description", "image": "image?id=1", "animation_url": "animation?id=1", "properties": {"number": 1, "name": "MOCK NAME"}}'
-        assertEq("data:application/json;base64,eyJuYW1lIjogIk1PQ0sgTkFNRSAxLzEwMCIsICJkZXNjcmlwdGlvbiI6ICJEZXNjcmlwdGlvbiIsICJpbWFnZSI6ICJpbWFnZT9pZD0xIiwgImFuaW1hdGlvbl91cmwiOiAiYW5pbWF0aW9uP2lkPTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyIjogMSwgIm5hbWUiOiAiTU9DSyBOQU1FIn19", editionRenderer.tokenURI(1));
+        // '{"name": "MOCK NAME 1/100", "description": "Description", "image": "image", "animation_url": "animation", "properties": {"number": 1, "name": "MOCK NAME"}}'
+        assertEq("data:application/json;base64,eyJuYW1lIjogIk1PQ0sgTkFNRSAxLzEwMCIsICJkZXNjcmlwdGlvbiI6ICJEZXNjcmlwdGlvbiIsICJpbWFnZSI6ICJpbWFnZT9pZD0xIiwgImFuaW1hdGlvbl91cmwiOiAiYW5pbWF0aW9uIiwgInByb3BlcnRpZXMiOiB7Im51bWJlciI6IDEsICJuYW1lIjogIk1PQ0sgTkFNRSJ9fQ==", editionRenderer.tokenURI(1));
     }
 
     function test_OpenEdition() public {
@@ -161,7 +159,7 @@ contract EditionMetadataRendererTest is DSTest {
         editionRenderer.initializeWithData(
             abi.encode("Description", "image", "animation")
         );
-        // {"name": "MOCK NAME 1", "description": "Description", "image": "image?id=1", "animation_url": "animation?id=1", "properties": {"number": 1, "name": "MOCK NAME"}}
-        assertEq("data:application/json;base64,eyJuYW1lIjogIk1PQ0sgTkFNRSAxIiwgImRlc2NyaXB0aW9uIjogIkRlc2NyaXB0aW9uIiwgImltYWdlIjogImltYWdlP2lkPTEiLCAiYW5pbWF0aW9uX3VybCI6ICJhbmltYXRpb24/aWQ9MSIsICJwcm9wZXJ0aWVzIjogeyJudW1iZXIiOiAxLCAibmFtZSI6ICJNT0NLIE5BTUUifX0=", editionRenderer.tokenURI(1));
+        // {"name": "MOCK NAME 1", "description": "Description", "image": "image", "animation_url": "animation", "properties": {"number": 1, "name": "MOCK NAME"}}
+        assertEq("data:application/json;base64,eyJuYW1lIjogIk1PQ0sgTkFNRSAxIiwgImRlc2NyaXB0aW9uIjogIkRlc2NyaXB0aW9uIiwgImltYWdlIjogImltYWdlP2lkPTEiLCAiYW5pbWF0aW9uX3VybCI6ICJhbmltYXRpb24iLCAicHJvcGVydGllcyI6IHsibnVtYmVyIjogMSwgIm5hbWUiOiAiTU9DSyBOQU1FIn19", editionRenderer.tokenURI(1));
     }
 }

--- a/test/metadata/MetadataRenderAdminCheck.t.sol
+++ b/test/metadata/MetadataRenderAdminCheck.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.10;
 
 import {EditionMetadataRenderer} from "../../src/metadata/EditionMetadataRenderer.sol";
 import {MetadataRenderAdminCheck} from "../../src/metadata/MetadataRenderAdminCheck.sol";
-import {SharedNFTLogic} from "../../src/utils/SharedNFTLogic.sol";
 import {DropMockBase} from "./DropMockBase.sol";
 import {DSTest} from "ds-test/test.sol";
 import {Vm} from "forge-std/Vm.sol";


### PR DESCRIPTION
1. Removes NFT rendering lib for editions in drops
2. Removes `?id=` suffix on paths for image and animations.
3. Updates/fixes tests for the latter.