### PR TITLE
I remove zora protocol fee

### DIFF
--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -11,7 +11,6 @@ export async function setupContracts() {
   const feeManagerAdminAddress = process.env.FEE_MANAGER_ADMIN_ADDRESS;
   const zoraERC721TransferHelperAddress =
     process.env.ZORA_ERC_721_TRANSFER_HELPER_ADDRESS;
-  const feeDefaultBPS = process.env.FEE_DEFAULT_BPS;
   let creatorProxyAddress = process.env.CREATOR_PROXY_ADDRESS;
 
   if (!zoraERC721TransferHelperAddress) {
@@ -30,16 +29,8 @@ export async function setupContracts() {
   const upgradeGateAddress = upgradeGate.deployed.deploy.deployedTo;
   console.log("Deployed upgrade gate to", upgradeGateAddress);
 
-  console.log("deploying fee manager");
-  const feeManager = await deployAndVerify(
-    "src/ZoraFeeManager.sol:ZoraFeeManager",
-    [feeDefaultBPS, feeManagerAdminAddress]
-  );
-  const feeManagerAddress = feeManager.deployed.deploy.deployedTo;
-  console.log("deployed fee manager to ", feeManagerAddress);
   console.log("deploying Erc721Drop");
   const dropContract = await deployAndVerify("src/ERC721Drop.sol:ERC721Drop", [
-    feeManagerAddress,
     zoraERC721TransferHelperAddress,
     upgradeGateAddress,
   ]);
@@ -81,7 +72,6 @@ export async function setupContracts() {
   }
 
   return {
-    feeManager,
     dropContract,
     dropMetadataContract,
     editionsMetadataContract,

--- a/src/interfaces/IERC721Drop.sol
+++ b/src/interfaces/IERC721Drop.sol
@@ -83,14 +83,10 @@ interface IERC721Drop {
     /// @param withdrawnBy address that issued the withdraw
     /// @param withdrawnTo address that the funds were withdrawn to
     /// @param amount amount that was withdrawn
-    /// @param feeRecipient user getting withdraw fee (if any)
-    /// @param feeAmount amount of the fee getting sent (if any)
     event FundsWithdrawn(
         address indexed withdrawnBy,
         address indexed withdrawnTo,
-        uint256 amount,
-        address feeRecipient,
-        uint256 feeAmount
+        uint256 amount
     );
 
     /// @notice Event emitted when an open mint is finalized and further minting is closed forever on the contract.
@@ -102,7 +98,6 @@ interface IERC721Drop {
     /// @param sender address of the updater
     /// @param renderer new metadata renderer address
     event UpdatedMetadataRenderer(address sender, IMetadataRenderer renderer);
-
 
     /// @notice General configuration for NFT Minting and bookkeeping
     struct Configuration {
@@ -206,7 +201,10 @@ interface IERC721Drop {
     /// @notice Update the metadata renderer
     /// @param newRenderer new address for renderer
     /// @param setupRenderer data to call to bootstrap data for the new renderer (optional)
-    function setMetadataRenderer(IMetadataRenderer newRenderer, bytes memory setupRenderer) external;
+    function setMetadataRenderer(
+        IMetadataRenderer newRenderer,
+        bytes memory setupRenderer
+    ) external;
 
     /// @notice This is an admin mint function to mint a quantity to a specific address
     /// @param to address to mint to

--- a/test/ERC721Drop.t.sol
+++ b/test/ERC721Drop.t.sol
@@ -7,51 +7,27 @@ import {IERC721AUpgradeable} from "erc721a-upgradeable/IERC721AUpgradeable.sol";
 
 import {IERC721Drop} from "../src/interfaces/IERC721Drop.sol";
 import {ERC721Drop} from "../src/ERC721Drop.sol";
-import {ZoraFeeManager} from "../src/ZoraFeeManager.sol";
 import {DummyMetadataRenderer} from "./utils/DummyMetadataRenderer.sol";
 import {MockUser} from "./utils/MockUser.sol";
 import {IMetadataRenderer} from "../src/interfaces/IMetadataRenderer.sol";
 import {FactoryUpgradeGate} from "../src/FactoryUpgradeGate.sol";
 import {ERC721DropProxy} from "../src/ERC721DropProxy.sol";
 
-// contract TestEventEmitter {
-//     function emitFundsWithdrawn(
-//         address withdrawnBy,
-//         address withdrawnTo,
-//         uint256 amount,
-//         address feeRecipient,
-//         uint256 feeAmount
-//     ) external {
-//         emit FundsWithdrawn(
-//             withdrawnBy,
-//             withdrawnTo,
-//             amount,
-//             feeRecipient,
-//             feeAmount
-//         );
-//     }
-// }
-
 contract ERC721DropTest is DSTest {
     /// @notice Event emitted when the funds are withdrawn from the minting contract
     /// @param withdrawnBy address that issued the withdraw
     /// @param withdrawnTo address that the funds were withdrawn to
     /// @param amount amount that was withdrawn
-    /// @param feeRecipient user getting withdraw fee (if any)
-    /// @param feeAmount amount of the fee getting sent (if any)
     event FundsWithdrawn(
         address indexed withdrawnBy,
         address indexed withdrawnTo,
-        uint256 amount,
-        address feeRecipient,
-        uint256 feeAmount
+        uint256 amount
     );
 
     ERC721Drop zoraNFTBase;
     MockUser mockUser;
     Vm public constant vm = Vm(HEVM_ADDRESS);
     DummyMetadataRenderer public dummyRenderer = new DummyMetadataRenderer();
-    ZoraFeeManager public feeManager;
     FactoryUpgradeGate public factoryUpgradeGate;
     address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
     address payable public constant DEFAULT_FUNDS_RECIPIENT_ADDRESS =
@@ -95,12 +71,9 @@ contract ERC721DropTest is DSTest {
 
     function setUp() public {
         vm.prank(DEFAULT_ZORA_DAO_ADDRESS);
-        feeManager = new ZoraFeeManager(500, DEFAULT_ZORA_DAO_ADDRESS);
         factoryUpgradeGate = new FactoryUpgradeGate(UPGRADE_GATE_ADMIN_ADDRESS);
         vm.prank(DEFAULT_ZORA_DAO_ADDRESS);
-        impl = address(
-            new ERC721Drop(feeManager, address(0x1234), factoryUpgradeGate)
-        );
+        impl = address(new ERC721Drop(address(0x1234), factoryUpgradeGate));
         address payable newDrop = payable(
             address(new ERC721DropProxy(impl, ""))
         );
@@ -182,11 +155,7 @@ contract ERC721DropTest is DSTest {
 
     function test_UpgradeApproved() public setupZoraNFTBase(10) {
         address newImpl = address(
-            new ERC721Drop(
-                ZoraFeeManager(address(0xadadad)),
-                address(0x3333),
-                factoryUpgradeGate
-            )
+            new ERC721Drop(address(0x3333), factoryUpgradeGate)
         );
 
         address[] memory lastImpls = new address[](1);
@@ -198,7 +167,6 @@ contract ERC721DropTest is DSTest {
         });
         vm.prank(DEFAULT_OWNER_ADDRESS);
         zoraNFTBase.upgradeTo(newImpl);
-        assertEq(address(zoraNFTBase.zoraFeeManager()), address(0xadadad));
     }
 
     function test_PurchaseTime() public setupZoraNFTBase(10) {
@@ -288,20 +256,13 @@ contract ERC721DropTest is DSTest {
         vm.deal(address(zoraNFTBase), amount);
         vm.prank(DEFAULT_OWNER_ADDRESS);
         vm.expectEmit(true, true, true, true);
-        uint256 leftoverFunds = amount - (amount * 1) / 20;
+        uint256 leftoverFunds = amount;
         emit FundsWithdrawn(
             DEFAULT_OWNER_ADDRESS,
             DEFAULT_FUNDS_RECIPIENT_ADDRESS,
-            leftoverFunds,
-            DEFAULT_ZORA_DAO_ADDRESS,
-            (amount * 1) / 20
+            leftoverFunds
         );
         zoraNFTBase.withdraw();
-
-        (, uint256 feeBps) = feeManager.getZORAWithdrawFeesBPS(
-            address(zoraNFTBase)
-        );
-        assertEq(feeBps, 500);
 
         assertTrue(
             DEFAULT_ZORA_DAO_ADDRESS.balance <
@@ -358,9 +319,7 @@ contract ERC721DropTest is DSTest {
             presaleMerkleRoot: bytes32(0)
         });
 
- 
-
-        (,,,,,uint64 presaleEndLookup,) = zoraNFTBase.salesConfig();
+        (, , , , , uint64 presaleEndLookup, ) = zoraNFTBase.salesConfig();
         assertEq(presaleEndLookup, 100);
 
         address SALES_MANAGER_ADDR = address(0x11002);
@@ -381,7 +340,15 @@ contract ERC721DropTest is DSTest {
             presaleMerkleRoot: bytes32(0)
         });
 
-        (,,,,uint64 presaleStartLookup2,uint64 presaleEndLookup2,) = zoraNFTBase.salesConfig();
+        (
+            ,
+            ,
+            ,
+            ,
+            uint64 presaleStartLookup2,
+            uint64 presaleEndLookup2,
+
+        ) = zoraNFTBase.salesConfig();
         assertEq(presaleEndLookup2, 0);
         assertEq(presaleStartLookup2, 100);
     }

--- a/test/ZoraNFTCreatorV1.t.sol
+++ b/test/ZoraNFTCreatorV1.t.sol
@@ -6,7 +6,6 @@ import {Vm} from "forge-std/Vm.sol";
 
 import {IMetadataRenderer} from "../src/interfaces/IMetadataRenderer.sol";
 import "../src/ZoraNFTCreatorV1.sol";
-import "../src/ZoraFeeManager.sol";
 import "../src/ZoraNFTCreatorProxy.sol";
 import {MockMetadataRenderer} from "./metadata/MockMetadataRenderer.sol";
 import {FactoryUpgradeGate} from "../src/FactoryUpgradeGate.sol";
@@ -26,13 +25,7 @@ contract ZoraFeeManagerTest is DSTest {
 
     function setUp() public {
         vm.prank(DEFAULT_ZORA_DAO_ADDRESS);
-        ZoraFeeManager feeManager = new ZoraFeeManager(
-            500,
-            DEFAULT_ZORA_DAO_ADDRESS
-        );
-        vm.prank(DEFAULT_ZORA_DAO_ADDRESS);
         dropImpl = new ERC721Drop(
-            feeManager,
             address(1234),
             FactoryUpgradeGate(address(0))
         );

--- a/test/merkle/MerkleDrop.t.sol
+++ b/test/merkle/MerkleDrop.t.sol
@@ -5,7 +5,6 @@ import {Vm} from "forge-std/Vm.sol";
 import {DSTest} from "ds-test/test.sol";
 import {IERC721Drop} from "../../src/interfaces/IERC721Drop.sol";
 import {ERC721Drop} from "../../src/ERC721Drop.sol";
-import {ZoraFeeManager} from "../../src/ZoraFeeManager.sol";
 import {DummyMetadataRenderer} from "../utils/DummyMetadataRenderer.sol";
 import {FactoryUpgradeGate} from "../../src/FactoryUpgradeGate.sol";
 import {ERC721DropProxy} from "../../src/ERC721DropProxy.sol";
@@ -16,7 +15,6 @@ contract ZoraNFTBaseTest is DSTest {
     ERC721Drop zoraNFTBase;
     Vm public constant vm = Vm(HEVM_ADDRESS);
     DummyMetadataRenderer public dummyRenderer = new DummyMetadataRenderer();
-    ZoraFeeManager public feeManager;
     MerkleData public merkleData;
     address public constant DEFAULT_OWNER_ADDRESS = address(0x23499);
     address payable public constant DEFAULT_FUNDS_RECIPIENT_ADDRESS =
@@ -51,17 +49,12 @@ contract ZoraNFTBaseTest is DSTest {
 
     function setUp() public {
         vm.prank(DEFAULT_ZORA_DAO_ADDRESS);
-        feeManager = new ZoraFeeManager(250, DEFAULT_ZORA_DAO_ADDRESS);
-        vm.prank(DEFAULT_ZORA_DAO_ADDRESS);
-
         address impl = address(
-            new ERC721Drop(
-                feeManager,
-                address(1234),
-                FactoryUpgradeGate(address(0))
-            )
+            new ERC721Drop(address(1234), FactoryUpgradeGate(address(0)))
         );
-        address payable newDrop = payable(address(new ERC721DropProxy(impl, "")));
+        address payable newDrop = payable(
+            address(new ERC721DropProxy(impl, ""))
+        );
         zoraNFTBase = ERC721Drop(newDrop);
         merkleData = new MerkleData();
     }


### PR DESCRIPTION
# Remove Zora Protocol Fee
- fees incentivize forks. 🍴 
- mandatory, centralized, fees are not an attribute of hyperstructures. :x:
- This PR removes `ZoraFee`. 🚮 
- This PR passes all unit tests. ✅ 
- This PR will prevent the need to fork Zora Drops to avoid fee. ✅ 

### Verified Deployments
- `FactoryUpgradeGate`: [0xa701dec0d72ae774f00b012744feb4e64edc2a2b](https://goerli.etherscan.io/address/0xa701dec0d72ae774f00b012744feb4e64edc2a2b#code)
- `ERC721Drop`: [0x4fe53ad5f8364d1f5eefa026be35ebd911fe5398](https://goerli.etherscan.io/address/0x4fe53ad5f8364d1f5eefa026be35ebd911fe5398#code)
- `DropMetadataRenderer`: [0x9022dfff27e858e36c87ae1acb7d9224e4bb6c63](https://goerli.etherscan.io/address/0x9022dfff27e858e36c87ae1acb7d9224e4bb6c63#code)
- `EditionMetadataRenderer`: [0xb7b2326faa0b00e7c786273e755555031f41963d](https://goerli.etherscan.io/address/0xb7b2326faa0b00e7c786273e755555031f41963d#code)
- `ZoraNFTCreatorV1`: [0x3c67e9c26c42ae1a7c6abca33ac8610ea8a1b8d6](https://goerli.etherscan.io/address/0x3c67e9c26c42ae1a7c6abca33ac8610ea8a1b8d6#code)
- `ZoraNFTCreatorProxy`: [0xcF3275597ce253F04849cE4A278e838771890203](https://goerli.etherscan.io/address/0xcF3275597ce253F04849cE4A278e838771890203#code)

### Unit Tests Passing. ✅ 
<img width="1440" alt="Screen Shot 2022-10-20 at 6 20 50 PM" src="https://user-images.githubusercontent.com/23249402/197061016-16aa08fb-57aa-45be-b7d6-25d359dcbb67.png">