### PR TITLE
Adding multicall support

### DIFF
--- a/src/ERC721Drop.sol
+++ b/src/ERC721Drop.sol
@@ -33,6 +33,7 @@ import {OwnableSkeleton} from "./utils/OwnableSkeleton.sol";
 import {FundsReceiver} from "./utils/FundsReceiver.sol";
 import {Version} from "./utils/Version.sol";
 import {ERC721DropStorageV1} from "./storage/ERC721DropStorageV1.sol";
+import {Multicall} from "@openzeppelin/contracts/utils/Multicall.sol";
 
 /**
  * @notice ZORA NFT Base contract for Drops and Editions
@@ -49,6 +50,7 @@ contract ERC721Drop is
     ReentrancyGuardUpgradeable,
     AccessControlUpgradeable,
     IERC721Drop,
+    Multicall,
     OwnableSkeleton,
     FundsReceiver,
     Version(8),

--- a/test/ERC721Drop.t.sol
+++ b/test/ERC721Drop.t.sol
@@ -256,6 +256,34 @@ contract ERC721DropTest is Test {
         );
     }
 
+    function test_MintMulticall() public setupZoraNFTBase(10) {
+        vm.startPrank(DEFAULT_OWNER_ADDRESS);
+        bytes[] memory calls = new bytes[](3);
+        calls[0] = abi.encodeWithSelector(
+            IERC721Drop.adminMint.selector,
+            DEFAULT_OWNER_ADDRESS,
+            5 
+        );
+        calls[1] = abi.encodeWithSelector(
+            IERC721Drop.adminMint.selector,
+            address(0x123),
+            3
+        );
+        calls[2] = abi.encodeWithSelector(
+            IERC721Drop.saleDetails.selector
+        );
+        bytes[] memory results = zoraNFTBase.multicall(calls);
+
+        (bool saleActive, bool presaleActive, uint256 publicSalePrice, , , , , , , ,) = abi.decode(results[2], (bool, bool, uint256, uint64, uint64, uint64, uint64, bytes32, uint256, uint256, uint256));
+        assertTrue(!saleActive);
+        assertTrue(!presaleActive);
+        assertEq(publicSalePrice, 0);
+        (uint256 firstMintedId) = abi.decode(results[0], (uint256));
+        (uint256 secondMintedId) = abi.decode(results[1], (uint256));
+        assertEq(firstMintedId, 5);
+        assertEq(secondMintedId, 8);
+    }
+
     function test_MintWrongValue() public setupZoraNFTBase(10) {
         vm.deal(address(456), 1 ether);
         vm.prank(address(456));
@@ -356,9 +384,7 @@ contract ERC721DropTest is Test {
             presaleMerkleRoot: bytes32(0)
         });
 
- 
-
-        (,,,,,uint64 presaleEndLookup,) = zoraNFTBase.salesConfig();
+        (, , , , , uint64 presaleEndLookup, ) = zoraNFTBase.salesConfig();
         assertEq(presaleEndLookup, 100);
 
         address SALES_MANAGER_ADDR = address(0x11002);
@@ -379,7 +405,15 @@ contract ERC721DropTest is Test {
             presaleMerkleRoot: bytes32(0)
         });
 
-        (,,,,uint64 presaleStartLookup2,uint64 presaleEndLookup2,) = zoraNFTBase.salesConfig();
+        (
+            ,
+            ,
+            ,
+            ,
+            uint64 presaleStartLookup2,
+            uint64 presaleEndLookup2,
+
+        ) = zoraNFTBase.salesConfig();
         assertEq(presaleEndLookup2, 0);
         assertEq(presaleStartLookup2, 100);
     }


### PR DESCRIPTION
This allows calling multicall for configuration variables.

Can help streamline deployment variables needed and allow for more granular configuration