### PR TITLE
Optimize registry performance for create

### DIFF
--- a/src/ERC721Drop.sol
+++ b/src/ERC721Drop.sol
@@ -56,7 +56,7 @@ contract ERC721Drop is
     PublicMulticall,
     OwnableSkeleton,
     FundsReceiver,
-    Version(9),
+    Version(10),
     ERC721DropStorageV1
 {
     /// @dev This is the max mint batch size for the optimized ERC721A mint contract
@@ -647,8 +647,8 @@ contract ERC721Drop is
         uint256 quantity
     ) internal virtual override {
         if (
-            from != msg.sender &&
-            address(operatorFilterRegistry).code.length > 0
+            from != address(0) && // skip on mints
+            from != msg.sender    // skip on transfers from sender
         ) {
             if (
                 !operatorFilterRegistry.isOperatorAllowed(


### PR DESCRIPTION
* Remove code size check – we know what chains we'll be deploying this code on and can validate the registry exists. no need to check this in that case for gas optimization.
* Don't check registry on mint events – gas optimization, since the exception for the from user creating the txn doesn't apply in this case and it's a common gas pattern.
