### PR TITLE
Guard initalization of impl contracts

### DIFF
--- a/src/ZoraNFTCreatorV1.sol
+++ b/src/ZoraNFTCreatorV1.sol
@@ -40,7 +40,7 @@ contract ZoraNFTCreatorV1 is OwnableUpgradeable, UUPSUpgradeable, Version(5) {
         address _implementation,
         EditionMetadataRenderer _editionMetadataRenderer,
         DropMetadataRenderer _dropMetadataRenderer
-    ) {
+    ) initializer {
         require(_implementation != address(0), CANNOT_BE_ZERO);
         require(
             address(_editionMetadataRenderer) != address(0),


### PR DESCRIPTION
Best practice to prevent users from initializing no-op implementation contracts.