### PR TITLE
Update contract version

### DIFF
--- a/.changeset/gorgeous-poets-cross.md
+++ b/.changeset/gorgeous-poets-cross.md
@@ -1,0 +1,5 @@
+---
+'@zoralabs/nft-drop-contracts': minor
+---
+
+Update contract minor version

--- a/src/ERC721Drop.sol
+++ b/src/ERC721Drop.sol
@@ -58,7 +58,7 @@ contract ERC721Drop is
     PublicMulticall,
     OwnableSkeleton,
     FundsReceiver,
-    Version(13),
+    Version(14),
     ERC721DropStorageV1,
     ERC721DropStorageV2
 {


### PR DESCRIPTION
Since we added `contractName` in this deployment, we need to update the factory contract version.

The impl contract version is already updated from the last change.